### PR TITLE
修复 Ubuntu 20.04 虚拟机（ROS Noetic and ROS 2 Humble，没有clang，只有gcc-9）编译问题

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -73,9 +73,12 @@ else
       if [ "$VERSION" == "22.04" ]; then
         export CC="clang-11"
         export CXX="clang++-11"
-      else 
+      elif [ "$VERSION" == "20.04" ] && [ -f /usr/bin/clang ]; then
         export CC="/usr/bin/clang"
         export CXX="/usr/bin/clang++"
+      else
+        export CC="/usr/bin/gcc"
+        export CXX="/usr/bin/g++"
       fi
     fi
 fi


### PR DESCRIPTION
还是优先使用clang

<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

## Screenshots (if appropriate):